### PR TITLE
fix: correct country detection inconsistencies in countries.csv

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -115,7 +115,7 @@ KH;Cambodia;Cambodia, Kampuchea, Kambodža, Cambodge
 KI;Kiribati;Kiribati
 KM;Comoros;Comor[oea]s
 KN;Saint Kitts and Nevis;Saint Kitts [&] Nevis, Saint-Christophe-et-Niévès
-KP;North Korea;(North|Seven[i]) Korea, Corée du Nord
+KP;North Korea;(North|Severn[í]) Korea, Corée du Nord
 KR;South Korea;(South|Jižní) Korea, Korea, Corée du Sud
 KW;Kuwait;Kuwait, Koweït
 KY;Cayman Islands;Cayman Islands, Kajmansk[é] Ostrovy, Îles Caïmans
@@ -166,7 +166,7 @@ NU;Niue;Niu[e]
 NZ;New Zealand;New Zealand, Zealand, Nov[ý] Z[é]land, Z[é]land, Nouvelle-Zélande
 OM;Oman;Om[a]n, ʻ?Um[ā]n
 PA;Panama;Panam[a]
-PE;Peru;Per[u], Piruw; Pérou
+PE;Peru;Per[u], Piruw, Pérou
 PF;French Polynesia;French Polynesia, Polyn[é]si[ae], Polynésie française
 PG;Papua New Guinea;Papua New Guinea, New Guinea, Papua Niu gini, Papouasie-Nouvelle-Guinée
 PH;Philippines;Philippines, Filip[í]ny, [PF]ilipinas
@@ -191,7 +191,7 @@ SC;Seychelles;Seychelles
 SD;Sudan;S[u]d[a]n
 SE;Sweden;S(ch)?weden, Sverige, [Š]v[é]dsko, Suecia, S[u][eè]de
 SG;Singapore;Singapore, Singap[u]r, Singapour
-SH;Saint Helena;(St|Saint) H?elena, Saint Hélène
+SH;Saint Helena;(St|Saint) H?elena, Sainte-Hélène
 SI;Slovenia;E?Slov[e]nij?[ae], Slovénie
 SJ;Svalbard and Jan Mayen;Svalbard [&] Jan Mayen
 SK;Slovakia;Slovak Republic, Slovakia, Slovensk[á] Republika, Slovensko, Slovaquie
@@ -243,7 +243,6 @@ ZM;Zambia;Zambi[ae]
 ZW;Zimbabwe;[ZS]imbab[wu][eé]
 ME;Montenegro;Mont[eé]n[eé]gro, Crna Gora, Црна Гора, [Č]ern[á] Hora
 XK;Kosovo;Kosov[oae], Косово
-RS;Serbia;Serbi[ae], Srbija, Србија, Srbsko
 GB-WLS;Wales;Wales
 GB-SCT;Scotland;Scotland, Skotsko, [EÉ]cosse
 GB-ENG;England;England, Inglaterra, Anglie, Angleterre

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"url": "git+ssh://git@github.com/jan-rus/country-in-text-detector.git"
 	},
 	"engines": {
-		"node": ">=1.0.0"
+		"node": ">=14.18.0"
 	},
 	"dependencies": {},
 	"bugs": {
@@ -27,6 +27,6 @@
 	},
 	"homepage": "https://github.com/jan-rus/country-in-text-detector#readme",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "node --test test.js"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,61 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var detector = require("./index.js");
+
+/**
+ * Extract the iso code from the result as the result looks like this
+ * [
+ *   {
+ *     iso3166: 'PE',
+ *     matches: [
+ *       'Pérou'
+ *     ],
+ *     name: 'Peru',
+ *     type: 'country'
+ *   }
+ * ]
+ */
+function extractIsoCodes(results) {
+	return results.map(function (r) { return r.iso3166; });
+}
+
+test("French 'Pérou' detects PE", function () {
+	var result = detector.detect("Je voyage au Pérou");
+	assert.ok(extractIsoCodes(result).includes("PE"), "expected PE in " + JSON.stringify(extractIsoCodes(result)));
+});
+
+test("Czech 'Severní Korea' detects KP", function () {
+	var result = detector.detect("Severní Korea");
+	assert.ok(extractIsoCodes(result).includes("KP"), "expected KP in " + JSON.stringify(extractIsoCodes(result)));
+});
+
+test("French 'Sainte-Hélène' detects SH", function () {
+	var result = detector.detect("Sainte-Hélène");
+	assert.ok(extractIsoCodes(result).includes("SH"), "expected SH in " + JSON.stringify(extractIsoCodes(result)));
+});
+
+test("French 'la Serbie' detects RS exactly once (no duplicate)", function () {
+	var result = detector.detect("la Serbie");
+	var rs = result.filter(function (r) { return r.iso3166 === "RS"; });
+	assert.equal(rs.length, 1, "expected exactly one RS entry, got " + rs.length);
+});
+
+test("'North Korea' detects KP", function () {
+	var result = detector.detect("North Korea");
+	assert.ok(extractIsoCodes(result).includes("KP"), "expected KP in " + JSON.stringify(extractIsoCodes(result)));
+});
+
+test("'Saint Helena' detects SH", function () {
+	var result = detector.detect("Saint Helena");
+	assert.ok(extractIsoCodes(result).includes("SH"), "expected SH in " + JSON.stringify(extractIsoCodes(result)));
+});
+
+test("'Peru' detects PE", function () {
+	var result = detector.detect("Peru");
+	assert.ok(extractIsoCodes(result).includes("PE"), "expected PE in " + JSON.stringify(extractIsoCodes(result)));
+});
+
+test("'Serbia' detects RS", function () {
+	var result = detector.detect("Serbia");
+	assert.ok(extractIsoCodes(result).includes("RS"), "expected RS in " + JSON.stringify(extractIsoCodes(result)));
+});


### PR DESCRIPTION
## Summary

Fixes 4 inconsistencies discovered in `data/countries.csv`:

- **`PE` (Peru)** — `;` instead of `,` between aliases caused « Pérou » to be silently dropped during CSV parsing (the `;` is the field separator in `lib/io.js`).
- **`KP` (North Korea)** — Czech alias `Seven[i]` matched the non-existent word « Seveni ». Corrected to `Severn[í]` (consistent with `Jižní` used for South Korea on the next line).
- **`SH` (Saint Helena)** — French alias `Saint Hélène` corrected to `Sainte-Hélène` (feminine + hyphenation, consistent with `Sainte-Lucie`, `Saint-Marin`, `Saint-Pierre-et-Miquelon`).
- **`RS` (Serbia)** — removed duplicate row at the bottom of the file; the canonical row (with « Serbie ») is kept.

## Test plan

- [x] « Je voyage au Pérou » → detects `PE`
- [x] « Severní Korea » → detects `KP`
- [x] « Sainte-Hélène » → detects `SH`
- [x] « la Serbie » → detects `RS` once (no duplicate)
- [x] No regression on existing matches (e.g. « North Korea », « Saint Helena », « Peru »)

Generated with claude